### PR TITLE
Add Docker Wait

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .vscode
+.env
+.env.dev
 **/.env
 **/.env.dev

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -18,7 +18,7 @@ services:
     env_file:
       - .env.dev
     command: >
-      sh -c "sh migrations.sh && python manage.py runserver 0.0.0.0:8000"
+      sh -c "/wait && sh migrations.sh && python manage.py runserver 0.0.0.0:8000"
     depends_on:
       - db
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,6 +1,9 @@
 #---- Base python ----
 FROM python:3.9-slim-bullseye as base
 
+ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.9.0/wait /wait
+RUN chmod +x /wait
+
 ENV PYTHONUNBUFFERED 1
 ENV PYTHONDONTWRITEBYTECODE 1
 


### PR DESCRIPTION
Adding a call to a 'wait' script in order to prevent the server service making calls to the db prior to it being ready. Without the wait script, the server's migration.sh script would often run too early and trigger errors - namely, no django superuser created. Closes #2